### PR TITLE
Route53 Deletes Fix

### DIFF
--- a/ingress_test.go
+++ b/ingress_test.go
@@ -59,11 +59,39 @@ var (
 		},
 	}
 
-	testIngressC = &v1beta1.Ingress{
+	testIngressC1 = &v1beta1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "exampleC",
+			Name:      "exampleC1",
 			Namespace: api.NamespaceDefault,
 			Labels:    map[string]string{},
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{Host: "baz.example.com"},
+			},
+		},
+	}
+
+	testIngressC2 = &v1beta1.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "exampleC2",
+			Namespace: api.NamespaceDefault,
+			Labels:    map[string]string{},
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{Host: "baz.example.com"},
+			},
+		},
+	}
+
+	testIngressC3 = &v1beta1.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "exampleC3",
+			Namespace: api.NamespaceDefault,
+			Labels: map[string]string{
+				"public": "true",
+			},
 		},
 		Spec: v1beta1.IngressSpec{
 			Rules: []v1beta1.IngressRule{

--- a/registrator.go
+++ b/registrator.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/miekg/dns"
@@ -223,8 +222,13 @@ func (r *registrator) applyBatch(changes []cnameChange) {
 		return
 	}
 
+	hostnames := make([]string, len(pruned))
+	for i, p := range pruned {
+		hostnames[i] = p.Hostname
+	}
+
 	if action == route53.ChangeActionDelete {
-		log.Printf("[INFO] deleting %d records", len(pruned))
+		log.Printf("[INFO] deleting %d records: %+v", len(pruned), hostnames)
 		if !*dryRun {
 			if err := r.DeleteCnames(pruned); err != nil {
 				log.Printf("[ERROR] error deleting records: %+v", err)
@@ -236,7 +240,7 @@ func (r *registrator) applyBatch(changes []cnameChange) {
 			}
 		}
 	} else {
-		log.Printf("[INFO] modifying %d records", len(pruned))
+		log.Printf("[INFO] modifying %d records: %+v", len(pruned), hostnames)
 		if !*dryRun {
 			if err := r.UpsertCnames(pruned); err != nil {
 				log.Printf("[ERROR] error modifying records: %+v", err)

--- a/registrator.go
+++ b/registrator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -291,17 +292,11 @@ func (r *registrator) pruneBatch(action string, records []cnameRecord) []cnameRe
 func (r *registrator) canHandleRecord(record string) bool {
 	zone := strings.Trim(r.Domain(), ".")
 	record = strings.Trim(record, ".")
-
-	if record == zone {
-		return false
+	matches, err := regexp.MatchString(fmt.Sprintf("^[^.]+\\.%s$", strings.Replace(zone, ".", "\\.", -1)), record)
+	if err != nil {
+		log.Printf("[DEBUG] regexp match error, will not handle record '%s': %+v", record, err)
 	}
-
-	zoneSuffix := "." + zone
-	if !strings.HasSuffix(record, zoneSuffix) {
-		return false
-	}
-
-	return !strings.Contains(strings.TrimSuffix(record, zoneSuffix), ".")
+	return matches
 }
 
 func resolveCname(name string, nameservers []string) (string, error) {

--- a/registrator_test.go
+++ b/registrator_test.go
@@ -102,7 +102,7 @@ func TestRegistratorHandler(t *testing.T) {
 	r := &registrator{
 		dnsZone:        mdz,
 		publicSelector: s,
-		updateQueue:    make(chan cnameRecord, 16),
+		updateQueue:    make(chan cnameChange, 16),
 		ingressWatcher: &ingressWatcher{
 			stopChannel: make(chan struct{}),
 		},
@@ -184,7 +184,7 @@ func TestRegistratorHandler(t *testing.T) {
 		r.ingressWatcher.stopChannel = make(chan struct{})
 		mdz.domain = test.domain
 		mdz.zoneData = map[string]string{}
-		r.updateQueue = make(chan cnameRecord, 16)
+		r.updateQueue = make(chan cnameChange, 16)
 		for _, e := range test.events {
 			r.handler(e.et, e.old, e.new)
 		}

--- a/registrator_test.go
+++ b/registrator_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"reflect"
 	"strings"
@@ -104,7 +105,7 @@ func (m *mockDNSZone) startMockDNSServer() (*dns.Server, error) {
 					Class:  dns.ClassINET,
 					Ttl:    0,
 				},
-				Target: target,
+				Target: fmt.Sprintf("%s.", target),
 			})
 		}
 		w.WriteMsg(msg)
@@ -221,10 +222,29 @@ func TestRegistratorHandler(t *testing.T) {
 		{
 			"example.com.",
 			[]mockEvent{
-				{watch.Added, nil, testIngressC},
+				{watch.Added, nil, testIngressC1},
 			},
 			map[string]string{
 				"baz.example.com": "priv.example.com",
+			},
+		},
+		{
+			"example.com.",
+			[]mockEvent{
+				{watch.Added, nil, testIngressC1},
+				{watch.Added, nil, testIngressC2},
+			},
+			map[string]string{},
+		},
+		{
+			"example.com.",
+			[]mockEvent{
+				{watch.Added, nil, testIngressC1},
+				{watch.Deleted, testIngressA, nil},
+				{watch.Modified, testIngressC1, testIngressC3},
+			},
+			map[string]string{
+				"baz.example.com": "pub.example.com",
 			},
 		},
 	}

--- a/route53.go
+++ b/route53.go
@@ -49,27 +49,15 @@ func (z *route53Zone) DeleteCnames(records []cnameRecord) error {
 
 func (z *route53Zone) changeCnames(action string, records []cnameRecord) error {
 	changes := make([]*route53.Change, len(records))
-	if action == route53.ChangeActionDelete {
-		for i, r := range records {
-			changes[i] = &route53.Change{
-				Action: aws.String(action),
-				ResourceRecordSet: &route53.ResourceRecordSet{
-					Name: aws.String(r.Hostname),
-					Type: aws.String(route53.RRTypeCname),
-				},
-			}
-		}
-	} else {
-		for i, r := range records {
-			changes[i] = &route53.Change{
-				Action: aws.String(action),
-				ResourceRecordSet: &route53.ResourceRecordSet{
-					Name:            aws.String(r.Hostname),
-					TTL:             aws.Int64(defaultRoute53RecordTTL),
-					Type:            aws.String(route53.RRTypeCname),
-					ResourceRecords: []*route53.ResourceRecord{{Value: aws.String(r.Target)}},
-				},
-			}
+	for i, r := range records {
+		changes[i] = &route53.Change{
+			Action: aws.String(action),
+			ResourceRecordSet: &route53.ResourceRecordSet{
+				Name:            aws.String(r.Hostname),
+				TTL:             aws.Int64(defaultRoute53RecordTTL),
+				Type:            aws.String(route53.RRTypeCname),
+				ResourceRecords: []*route53.ResourceRecord{{Value: aws.String(r.Target)}},
+			},
 		}
 	}
 

--- a/route53_test.go
+++ b/route53_test.go
@@ -232,7 +232,7 @@ func TestRoute53Zone_DeleteCname(t *testing.T) {
 		t.Fatalf("newRoute53Zone returned unexpected error: %+v", err)
 	}
 
-	if err := p.DeleteCnames([]cnameRecord{{Hostname: "test.example.com"}}); err != nil {
+	if err := p.DeleteCnames([]cnameRecord{{Hostname: "test.example.com", Target: "foo.example.com"}}); err != nil {
 		t.Errorf("Route53Zone.DeleteCname returned unexpected error: %+v", err)
 	}
 }


### PR DESCRIPTION
When deleting a record from Route53 you need to specify its value as well (`ResourceRecords`).

This changes the way deletions are handled in `ingress53`.