### PR TITLE
remove default target and ignore functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ You can test it locally (please refer to the command line help for more options)
     -route53-zone-id=XXXXXXXXXXXXXX \
     -target=private.cluster-entrypoint.com \
     -target=public.cluster-entrypoint.com \
-    -default-target=private.cluster-entrypoint.com \
     -kubernetes-config=$HOME/.kube/config \
     -dry-run
 ```
@@ -135,7 +134,6 @@ spec:
           - -route53-zone-id=XXXXXXXXXXXXXX
           - -target=private.cluster-entrypoint.com
           - -target=public.cluster-entrypoint.com
-          - -default-target=private.cluster-entrypoint.com
         resources:
           requests:
             cpu: 10m

--- a/ingress_test.go
+++ b/ingress_test.go
@@ -31,22 +31,6 @@ var (
 		},
 	}
 
-	privateIngressHostAIgnored = &v1beta1.Ingress{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "privateIngressHostA",
-			Namespace: api.NamespaceDefault,
-			Labels: map[string]string{
-				testTargetLabelName: testPrivateTarget,
-				testIgnoreLabelName: "true",
-			},
-		},
-		Spec: v1beta1.IngressSpec{
-			Rules: []v1beta1.IngressRule{
-				{Host: "a.example.com"},
-			},
-		},
-	}
-
 	publicIngressHostC = &v1beta1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "publicIngressHostCD",

--- a/main.go
+++ b/main.go
@@ -47,8 +47,6 @@ var (
 
 	kubeConfig      = flag.String("kubernetes-config", "", "path to the kubeconfig file, if unspecified then in-cluster config will be used")
 	targetLabelName = flag.String("target-label", "ingress53.target", "Kubernetes key of the label that specifies the target type")
-	ingoreLabelName = flag.String("ignore-label", "ingress53.ignore", "Kubernetes key of the label that determines whether an ingress should be ignored")
-	defaultTarget   = flag.String("default-target", "", "Default target to use in the absense of matching labels")
 	r53ZoneID       = flag.String("route53-zone-id", "", "route53 hosted DNS zone id")
 	debugLogs       = flag.Bool("debug", false, "enables debug logs")
 	dryRun          = flag.Bool("dry-run", false, "if set, ingress53 will not make any Route53 changes")
@@ -105,8 +103,6 @@ func main() {
 	ro := registratorOptions{
 		Targets:         targets,
 		TargetLabelName: *targetLabelName,
-		IgnoreLabelName: *ingoreLabelName,
-		DefaultTarget:   *defaultTarget,
 		Route53ZoneID:   *r53ZoneID,
 	}
 	if *kubeConfig != "" {


### PR DESCRIPTION
- the default target can be confusing, explicitly setting the target for every Ingress turns out to be a better solution
- by losing the default target, the ignore label has no reason to exist

Overall, this PR should reduce complexity.