### PR TITLE
Introduce metric on errors from kube api calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
   && apk add --no-cache --virtual=.builddeps \
         -X http://dl-cdn.alpinelinux.org/alpine/edge/community \
         git \
-        go \
+        go=1.8.4-r0 \
         musl-dev \
   && export GOPATH=/go \
   && cd $GOPATH/src/${IMPORT_PATH} \


### PR DESCRIPTION
1. Add error handler to keep count of kube api errors
2. Pin older go version to avoid certificates issue